### PR TITLE
startScreen update

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,18 +4,60 @@ var init = function (p5) {
     var spark; //our spark is a point
     var spark_dx; //change in spark location per frame
     
+    var screen; //keeps track of which screen to display
+    
 	//p5.setup runs once before p5.draw is run
 	p5.setup  = function () {
 		p5.createCanvas(600, 600);
+        p5.stroke(0);
+        p5.strokeWeight(1);
+        p5.fill(155);
+        screen = 0; //sets screen to startScreen
         numberLine = new NumberLine(0, p5.height/2, p5.width, 40, 0, p5);
         rope = new Line(0, 300, numberLine.length(), 300, p5);
         spark = new Point(0, 300, p5);
         spark_dx = 1;
+        
 	};
 
     //p5.draw runs every frame by default
 	p5.draw = function () {
-		p5.background(255);
+		if (screen === 0) {
+            startScreen();
+        }
+        if (screen === 1) {
+            gameScreen();
+        } else {
+            
+        }
+	};
+    
+    //displays startScreen, could pass variables to gameScreen() for levels, help page, ect.
+    function startScreen() {
+        p5.background(255);
+        var playButton = p5.rect(175, 150, 125, 80);
+        var helpButton = p5.rect(175, 250, 125, 80);
+        
+        p5.fill(0);
+        p5.textSize(32);
+        p5.text(" Start Game", 190, 140, 125,80);
+        p5.text("Help", 200, 260, 125, 80);
+        
+        
+        p5.mouseReleased = function () {
+            if (175 < p5.mouseX && 300 > p5.mouseX  && 150 < p5.mouseY && 280 > p5.mouseY){
+                p5.background(0);
+                screen = 1;//screen to gameScreen();
+            } if (175 < p5.mouseX && 300 > p5.mouseX  && 250 < p5.mouseY && 380 > p5.mouseY){
+                p5.background(0);
+                screen = 2;//screen to gameScreen();
+            }else{
+            }
+        }
+    };
+    
+    function gameScreen() {
+        p5.background(255);
         //draw number line:
         numberLine.draw();
         
@@ -37,13 +79,16 @@ var init = function (p5) {
             rope.translate(spark_dx, 0);
             spark.translate(spark_dx, 0);
         }
-	};
-	p5.keyPressed = function () {
-        	if (p5.keyCode === p5.UP_ARROW) {
-            		p5.noLoop();
-    
-        	}
-    	}; 
+        
+        //in gameScreen() so no interference with startScreen().
+        p5.keyPressed = function () {
+            if (p5.keyCode === p5.UP_ARROW) {
+    		  screen = 0;
+              
+            }
+        };
+    }
+
 };
 
 var myp5 = new p5 (init);


### PR DESCRIPTION
Got a working start screen. It is currently implemented by having startScreen() and gameScreen methods within the app.js file. I could not figure out how to call another p5 object from another. This method is not ideal because it includes an extra method call (to gameScreen() or startSceen() ) at each cycle of draw.
